### PR TITLE
We don't want to run the instrumentation unless we need to. For one, …

### DIFF
--- a/Public/TestEVM/Builtin/SafeCasting/Default.conf
+++ b/Public/TestEVM/Builtin/SafeCasting/Default.conf
@@ -4,4 +4,5 @@
     ],
     verify: "C:C.spec",
     "solc": "solc8.28",
+    "safe_casting_builtin": true
 }

--- a/lib/Shared/src/main/kotlin/config/Config.kt
+++ b/lib/Shared/src/main/kotlin/config/Config.kt
@@ -2487,6 +2487,15 @@ object Config {
         )
     ) {}
 
+    val SafeCastingBuiltin: ConfigType.BooleanCmdLine = object : ConfigType.BooleanCmdLine(
+        false,
+        Option(
+            "safeCastingBuiltin", true,
+            "Used to signal that the python side instrumented the safeCasting builtin rule [default: false]"
+        ),
+        pythonName = "--safe_casting_builtin"
+    ) {}
+
     val CallTraceHardFail = object : ConfigType.HardFailCmdLine(
         HardFailMode.OFF,
         Option(

--- a/scripts/CertoraProver/certoraBuild.py
+++ b/scripts/CertoraProver/certoraBuild.py
@@ -3339,14 +3339,15 @@ class CertoraBuildGenerator:
         else:
             added_source_finders = {}
 
-        try:
-            casting_instrumentations, casting_types = generate_casting_instrumentation(self.asts, build_arg_contract_file, sdc_pre_finder)
-        except Exception as e:
-            instrumentation_logger.warning(
-                f"Computing casting instrumentation failed for {build_arg_contract_file}: {e}", exc_info=True)
-            casting_instrumentations, casting_types = {}, {}
+        if self.context.safe_casting_builtin:
+            try:
+                casting_instrumentations, casting_types = generate_casting_instrumentation(self.asts, build_arg_contract_file, sdc_pre_finder)
+            except Exception as e:
+                instrumentation_logger.warning(
+                    f"Computing casting instrumentation failed for {build_arg_contract_file}: {e}", exc_info=True)
+                casting_instrumentations, casting_types = {}, {}
 
-        instr = CertoraBuildGenerator.merge_dicts_instrumentation(instr, casting_instrumentations)
+            instr = CertoraBuildGenerator.merge_dicts_instrumentation(instr, casting_instrumentations)
 
         abs_build_arg_contract_file = Util.abs_posix_path(build_arg_contract_file)
         if abs_build_arg_contract_file not in instr:
@@ -3401,12 +3402,13 @@ class CertoraBuildGenerator:
                         read_so_far += amt + 1 + to_skip
                     output.write(in_file.read(-1))
 
-                    library_name, funcs = casting_types.get(contract_file, ("", list()))
-                    if len(funcs) > 0:
-                        output.write(bytes(f"\nlibrary {library_name}" + "{\n", "utf8"))
-                        for f in funcs:
-                            output.write(bytes(f, "utf8"))
-                        output.write(bytes("}\n", "utf8"))
+                    if self.context.safe_casting_builtin:
+                        library_name, funcs = casting_types.get(contract_file, ("", list()))
+                        if len(funcs) > 0:
+                            output.write(bytes(f"\nlibrary {library_name}" + "{\n", "utf8"))
+                            for f in funcs:
+                                output.write(bytes(f, "utf8"))
+                            output.write(bytes("}\n", "utf8"))
 
         new_file = self.to_autofinder_file(build_arg_contract_file)
         self.context.file_to_contract[new_file] = self.context.file_to_contract[

--- a/scripts/CertoraProver/certoraContextAttributes.py
+++ b/scripts/CertoraProver/certoraContextAttributes.py
@@ -1202,6 +1202,19 @@ class EvmAttributes(AttrUtil.Attributes):
         disables_build_cache=False,
     )
 
+    SAFE_CASTING_BUILTIN = AttrUtil.AttributeDefinition(
+        arg_type=AttrUtil.AttrArgType.BOOLEAN,
+        help_msg="This needs to be set to true for the safeCasting builtin to work",
+        default_desc="This needs to be set to true for the safeCasting builtin to work",
+        jar_flag='-safeCastingBuiltin',
+        argparse_args={
+            'action': AttrUtil.STORE_TRUE,
+            'default': False
+        },
+        affects_build_cache_key=True,
+        disables_build_cache=False,
+    )
+
     @classmethod
     def hide_attributes(cls) -> List[str]:
         # do not show these attributes in the help message

--- a/src/main/kotlin/analysis/ip/SafeCastingAnnotator.kt
+++ b/src/main/kotlin/analysis/ip/SafeCastingAnnotator.kt
@@ -19,6 +19,7 @@ package analysis.ip
 
 import analysis.CmdPointer
 import analysis.MustBeConstantAnalysis
+import config.Config
 import datastructures.stdcollections.*
 import tac.MetaKey
 import utils.*
@@ -62,6 +63,9 @@ object SafeCastingAnnotator {
      * builtin rule.
      */
     fun annotate(code: CoreTACProgram): CoreTACProgram {
+        if (!Config.SafeCastingBuiltin.get()) {
+            return code
+        }
         val g = code.analysisCache.graph
         val constantAnalysis = MustBeConstantAnalysis(g)
 

--- a/src/main/kotlin/rules/genericrulecheckers/BuiltInRuleCustomChecker.kt
+++ b/src/main/kotlin/rules/genericrulecheckers/BuiltInRuleCustomChecker.kt
@@ -18,6 +18,7 @@
 package rules.genericrulecheckers
 
 import analysis.icfg.Inliner
+import config.Config
 import datastructures.stdcollections.*
 import log.*
 import report.*
@@ -88,6 +89,10 @@ sealed class BuiltInRuleCustomChecker<G : BuiltInRuleGenerator> {
                     TrustedMethodChecker()
                 }
                 BuiltInRuleId.safeCasting -> {
+                    require(Config.SafeCastingBuiltin.get()) {
+                        "The safeCasting rule can't run unless ${Config.SafeCastingBuiltin.pythonName} is set to true " +
+                            "on the command line (or conf file)"
+                    }
                     SafeCastingChecker
                 }
                 BuiltInRuleId.msgValueInLoopRule -> {


### PR DESCRIPTION
…it adds a function call for every casting operation. It also messes a bit with the colum numbers on the src pointers...

Also, at this stage it is safer to put this under a flag: --safe_casting_builtin, which is by default false.

44210b058b47765d653ade8ba8dd66e4ee3836f4